### PR TITLE
Better support for older browsers

### DIFF
--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -31,7 +31,7 @@ $mobile: 768px;
       display: block;
     }
 
-    th, td {
+    td {
       display: block; // For browsers that don't support flexbox
       display: flex;
       justify-content: space-between;

--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -77,6 +77,18 @@
 
       td {
         min-width: 1px;
+        text-align: right;
+
+        @at-root {
+
+          .lte-ie8 & {
+            text-align: left;
+          }
+        }
+
+        @media (min-width: $mobile) {
+          text-align: left;
+        }
 
         &.numeric {
           text-align: left;

--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -79,13 +79,6 @@
         min-width: 1px;
         text-align: right;
 
-        @at-root {
-
-          .lte-ie8 & {
-            text-align: left;
-          }
-        }
-
         @media (min-width: $mobile) {
           text-align: left;
         }

--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -49,6 +49,7 @@
       font-weight: 700;
       text-align: left;
       padding-right: 1em;
+      display: block;
 
       @media (min-width: $mobile) {
         display: none;

--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -32,10 +32,11 @@ $mobile: 768px;
     }
 
     th, td {
+      display: block; // For browsers that don't support flexbox
       display: flex;
       justify-content: space-between;
       vertical-align: middle;
-  
+
       @media (min-width: $mobile) {
         display: table-cell;
       }
@@ -44,7 +45,6 @@ $mobile: 768px;
         padding-right: 0;
       }
     }
-
 
     .table-heading {
       font-weight: 700;
@@ -69,6 +69,7 @@ $mobile: 768px;
 
       th {
         text-align: right;
+
         @media (min-width: $mobile) {
           text-align: left;
         }
@@ -76,12 +77,11 @@ $mobile: 768px;
 
       td {
         min-width: 1px;
-        text-align: right;
 
-        @media (min-width: $mobile) {
+        &.numeric {
           text-align: left;
 
-          &.numeric {
+          @media (min-width: $mobile) {
             text-align: right;
           }
         }

--- a/app/assets/sass/tables/transactions.scss
+++ b/app/assets/sass/tables/transactions.scss
@@ -1,6 +1,5 @@
-$mobile: 768px;
-
 .responsive-table {
+  $mobile: 768px;
   width: 100%;
 
   thead {


### PR DESCRIPTION
- Makes Internet Explorer 8 a bit more readable
- Scopes `$mobile` variable to the `responsive-table`
- refines CSS output a wee bit by removing unnecessary `tbody th` styling

IE8 isn't as tidy as it might be with some `.ie8` specific styles, but those just aren't worth the overhead. Not great looking as the media queries are `min-width`, but changing them to non-mobile-first `max-width` just for IE8 (which isn't even strictly supported) is the wrong thing to do. IE8 users can be grateful it's readable 😉

It also looks a bit tidier on non-flexbox mobile browsers.
